### PR TITLE
aws-c-auth 0.8.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,8 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
+  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9
+  - https://staging.continuum.io/prefect/fs/aws-c-http-feedstock/pr2/36b51e2
+  - https://staging.continuum.io/prefect/fs/aws-c-sdkutils-feedstock/pr2/4e92b37

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/aws-c-compression-feedstock/pr2/854701d
-  - https://staging.continuum.io/prefect/fs/aws-c-io-feedstock/pr2/bf28bef
-  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr2/071091c
-  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr2/9f12ab9
-  - https://staging.continuum.io/prefect/fs/aws-c-http-feedstock/pr2/36b51e2
-  - https://staging.continuum.io/prefect/fs/aws-c-sdkutils-feedstock/pr2/4e92b37

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
     - aws-c-cal 0.8.5
     - aws-c-common 0.11.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.5" %}
+{% set version = "0.8.6" %}
 
 package:
   name: aws-c-auth
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-auth/archive/v{{ version }}.tar.gz
-  sha256: 302f40c189456defe14860d13a22a6bf435cdb9eee2b60c585e8725825385cbb
+  sha256: 5f5df716d02a2b973ec685f1b50749b2e82736599189926817fbca00cfb194d7
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: 'C99 library implementation of AWS client-side authentication: standard credentials providers and signing.'
+  description: |
+    C99 library implementation of AWS client-side authentication: standard credentials providers and signing.
+    From a cryptographic perspective, only functions with the suffix "_constant_time" should be considered constant time.
+  doc_url: https://github.com/awslabs/aws-c-auth
+  dev_url: https://github.com/awslabs/aws-c-auth
 extra:
   recipe-maintainers:
     - xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - cmake
     - {{ compiler('c') }}
     - ninja
-    - aws-c-common
   host:
     - aws-c-cal 0.8.5
     - aws-c-common 0.11.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.6" %}
+{% set version = "0.8.5" %}
 
 package:
   name: aws-c-auth
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-auth/archive/v{{ version }}.tar.gz
-  sha256: 5f5df716d02a2b973ec685f1b50749b2e82736599189926817fbca00cfb194d7
+  sha256: 302f40c189456defe14860d13a22a6bf435cdb9eee2b60c585e8725825385cbb
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.6.19" %}
+{% set version = "0.8.5" %}
 
 package:
   name: aws-c-auth
@@ -6,9 +6,7 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-auth/archive/v{{ version }}.tar.gz
-  sha256: 2b6b05e046227f87c39d0dd821759273c80e864689dfb36bbc64bed86dc8336f
-  patches:                                # [linux64 or (linux and aarch64)]
-    - 0001-skip-test-failing-on-CI.patch  # [linux64 or (linux and aarch64)]
+  sha256: 302f40c189456defe14860d13a22a6bf435cdb9eee2b60c585e8725825385cbb
 
 build:
   number: 0
@@ -19,14 +17,14 @@ requirements:
   build:
     - cmake
     - {{ compiler('c') }}
-    - ninja-base
-    - patch  # [linux64 or (linux and aarch64)]
+    - ninja
+    - aws-c-common
   host:
-    - aws-c-cal 0.5.20
-    - aws-c-common 0.8.5
-    - aws-c-http 0.6.25
-    - aws-c-io 0.13.10
-    - aws-c-sdkutils 0.1.6
+    - aws-c-cal
+    - aws-c-common
+    - aws-c-http
+    - aws-c-io
+    - aws-c-sdkutils
 
 test:
   commands:
@@ -41,11 +39,6 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: 'C99 library implementation of AWS client-side authentication: standard credentials providers and signing.'
-  description: |
-    C99 library implementation of AWS client-side authentication: standard credentials providers and signing.
-    From a cryptographic perspective, only functions with the suffix "_constant_time" should be considered constant time.
-  dev_url: https://github.com/awslabs/aws-c-auth
-  doc_url: https://github.com/awslabs/aws-c-auth
 extra:
   recipe-maintainers:
     - xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,11 +20,11 @@ requirements:
     - ninja
     - aws-c-common
   host:
-    - aws-c-cal
-    - aws-c-common
-    - aws-c-http
-    - aws-c-io
-    - aws-c-sdkutils
+    - aws-c-cal 0.8.5
+    - aws-c-common 0.11.1
+    - aws-c-http 0.9.3
+    - aws-c-io 0.17.0
+    - aws-c-sdkutils 0.2.3
 
 test:
   commands:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7292](https://anaconda.atlassian.net/browse/PKG-7292)
- [Upstream repository](https://github.com/awslabs/aws-c-auth/tree/v0.8.6)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Update version
- Update dependencies
- Linter fixes


[PKG-7292]: https://anaconda.atlassian.net/browse/PKG-7292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ