### PR TITLE
aws-c-auth 0.9.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
+{% set name = "aws-c-auth" %}
 {% set version = "0.9.0" %}
 
 package:
-  name: aws-c-auth
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/awslabs/aws-c-auth/archive/v{{ version }}.tar.gz
+  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: aa6e98864fefb95c249c100da4ae7aed36ba13a8a91415791ec6fad20bec0427
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-c-auth", max_pin="x.x.x") }}
 
@@ -21,9 +22,9 @@ requirements:
   host:
     - aws-c-cal 0.9.2
     - aws-c-common 0.12.3
-    - aws-c-http 0.9.3
-    - aws-c-io 0.17.0
-    - aws-c-sdkutils 0.2.3
+    - aws-c-http 0.10.2
+    - aws-c-io 0.20.1
+    - aws-c-sdkutils 0.2.4
 
 test:
   commands:


### PR DESCRIPTION
aws-c-auth 0.9.0 

**Destination channel:** Defaults

### Links

- [PKG-8704]
- dev_url:        https://github.com/awslabs/aws-c-auth/tree/v0.9.0
- conda_forge:    https://github.com/conda-forge/aws-c-auth-feedstock
- pypi:           https://pypi.org/project/aws-c-auth/0.9.0
- pypi inspector: https://inspector.pypi.io/project/aws-c-auth/0.9.0/

### Explanation of changes:

- new version number
